### PR TITLE
Add unit tests for JWT utilities and service

### DIFF
--- a/src/test/java/lt/ca/javau12/jwt/security/JwtUtilsTest.java
+++ b/src/test/java/lt/ca/javau12/jwt/security/JwtUtilsTest.java
@@ -1,0 +1,40 @@
+package lt.ca.javau12.jwt.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class JwtUtilsTest {
+
+    private static final String SECRET = "manolabaiilgakazkokiaraktueilute";
+    private static final long EXPIRATION_MS = 3600000; // 1h
+
+    @Test
+    void generatedTokenContainsSameUsername() {
+        JwtUtils utils = new JwtUtils(SECRET, EXPIRATION_MS);
+        String token = utils.generateToken("alice");
+        assertEquals("alice", utils.extractUsername(token));
+    }
+
+    @Test
+    void validateTokenWithCorrectUsername() {
+        JwtUtils utils = new JwtUtils(SECRET, EXPIRATION_MS);
+        String token = utils.generateToken("alice");
+        assertTrue(utils.validateToken(token, "alice"));
+    }
+
+    @Test
+    void validateTokenWithIncorrectUsername() {
+        JwtUtils utils = new JwtUtils(SECRET, EXPIRATION_MS);
+        String token = utils.generateToken("alice");
+        assertFalse(utils.validateToken(token, "bob"));
+    }
+
+    @Test
+    void validateTokenReturnsFalseWhenExpired() throws InterruptedException {
+        JwtUtils utils = new JwtUtils(SECRET, 1); // token expires almost immediately
+        String token = utils.generateToken("alice");
+        Thread.sleep(5);
+        assertFalse(utils.validateToken(token, "alice"));
+    }
+}

--- a/src/test/java/lt/ca/javau12/jwt/services/MyUserDetailsServiceTest.java
+++ b/src/test/java/lt/ca/javau12/jwt/services/MyUserDetailsServiceTest.java
@@ -1,0 +1,41 @@
+package lt.ca.javau12.jwt.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import lt.ca.javau12.jwt.models.Role;
+import lt.ca.javau12.jwt.models.User;
+import lt.ca.javau12.jwt.repository.UserRepository;
+
+class MyUserDetailsServiceTest {
+
+    @Test
+    void loadsExistingUser() {
+        UserRepository repo = mock(UserRepository.class);
+        User user = new User(1L, "bob", "secret", Role.USER, true);
+        when(repo.findByUsername("bob")).thenReturn(Optional.of(user));
+        MyUserDetailsService service = new MyUserDetailsService(repo);
+
+        UserDetails details = service.loadUserByUsername("bob");
+        assertEquals("bob", details.getUsername());
+        assertEquals("secret", details.getPassword());
+        assertTrue(details.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_USER")));
+    }
+
+    @Test
+    void throwsWhenUserNotFound() {
+        UserRepository repo = mock(UserRepository.class);
+        when(repo.findByUsername("bob")).thenReturn(Optional.empty());
+        MyUserDetailsService service = new MyUserDetailsService(repo);
+
+        assertThrows(UsernameNotFoundException.class,
+                () -> service.loadUserByUsername("bob"));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for JwtUtils
- add tests for MyUserDetailsService

## Testing
- `./mvnw -q test` *(fails: cannot fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd985d3c832ea2d128d5e79a3252